### PR TITLE
Explicit DBUS signature for get_installed_packages

### DIFF
--- a/software_loading_manager.py
+++ b/software_loading_manager.py
@@ -340,7 +340,7 @@ class SLMService(dbus.service.Object):
                                             result_code,
                                             result_text)
 
-    @dbus.service.method("org.genivi.software_loading_manager")
+    @dbus.service.method("org.genivi.software_loading_manager", out_signature='aa{sv}')
     def get_installed_packages(self): 
         print "Got get_installed_packages()"
         return [ { "package_id": "bluez_driver", 


### PR DESCRIPTION
Without an explicit signature, python's DBUS API attempts to guess the return
type of the function call. The mixed type dictionary confuses it, and an error
like ERROR:dbus.service:Unable to append... is reported.
